### PR TITLE
Use a dynamic mesh access region with explicit reinitialization

### DIFF
--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -140,8 +140,6 @@ void ParallelCouplingScheme::exchangeSecondData()
     moveToNextWindow();
   } else {
     PRECICE_ASSERT(isImplicitCouplingScheme());
-    PRECICE_ASSERT(false, "Not (yet) considered");
-
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Receiving convergence data...");
       receiveConvergence(getM2N());

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -72,7 +72,6 @@ void Data::moveToNextWindow()
 void Data::setSampleAtTime(double time, const time::Sample &sample)
 {
   PRECICE_ASSERT(sample.dataDims == getDimensions(), "Sample has incorrect data dimension");
-  PRECICE_ASSERT(sample.values.size() == _sample.values.size(), "Inconsistent sizes of samples");
   setGlobalSample(sample); // @todo at some point we should not need this anymore, when mapping, acceleration ... directly work on _timeStepsStorage, see https://github.com/precice/precice/issues/1645
   _waveform.timeStepsStorage().setSampleAtTime(time, sample);
 }

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -114,6 +114,11 @@ void Participant::resetMeshAccessRegion(::precice::string_view meshName)
   return _impl->resetMeshAccessRegion(toSV(meshName));
 }
 
+bool Participant::reinitializeAPIAccess()
+{
+  return _impl->reinitializeAPIAccess();
+}
+
 bool Participant::requiresGradientDataFor(::precice::string_view meshName,
                                           ::precice::string_view dataName) const
 {

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -1110,6 +1110,10 @@ public:
   void resetMeshAccessRegion(::precice::string_view meshName);
   ///@}
 
+  /// asks preCICE to figure out if any mesh changes became relevant to this participant
+  /// returns true, if the mesh in the access region changed and false, if the mesh in the access region did not change
+  bool reinitializeAPIAccess();
+
   /** @name Experimental: Gradient Data
    * These API functions are \b experimental and may change in future versions.
    */

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -301,7 +301,6 @@ void ParticipantImpl::reinitialize()
   PRECICE_TRACE();
   PRECICE_ASSERT(_allowsRemeshing);
 
-  PRECICE_DEBUG("Handling direct-access data before reinitialization");
   PRECICE_ASSERT(_couplingScheme->isTimeWindowComplete());
   // In case we have data written via direct access, we need to first exchange these data samples
   // Step 1: store data for those data contexts

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -305,17 +305,17 @@ void ParticipantImpl::reinitialize()
   PRECICE_ASSERT(_couplingScheme->isTimeWindowComplete());
   // In case we have data written via direct access, we need to first exchange these data samples
   // Step 1: store data for those data contexts
-  for (auto &context : _accessor->writeDataContexts()) {
-    if (_accessor->isDirectAccessAllowed(context.getMeshName())) {
-      context.completeJustInTimeMapping();
-      context.storeBufferedData(_couplingScheme->getTime());
-      context.resetBufferedData();
-    }
-  }
+  // for (auto &context : _accessor->writeDataContexts()) {
+  //   if (_accessor->isDirectAccessAllowed(context.getMeshName())) {
+  //     context.completeJustInTimeMapping();
+  //     context.storeBufferedData(_couplingScheme->getTime());
+  //     context.resetBufferedData();
+  //   }
+  // }
 
   // Step 2: exchange the data
-  PRECICE_DEBUG("Exchanging direct access data");
-  _couplingScheme->exchangeDirectAccessData();
+  // PRECICE_DEBUG("Exchanging direct access data");
+  // _couplingScheme->exchangeDirectAccessData();
 
   PRECICE_INFO("Reinitializing Participant");
   Event e("reinitialize", profiling::Fundamental);
@@ -426,17 +426,20 @@ void ParticipantImpl::advance(
   PRECICE_CHECK(computedTimeStepSize > 0.0, "advance() cannot be called with a negative time step size {}.", computedTimeStepSize);
   _numberAdvanceCalls++;
 
-#ifndef NDEBUG
-  PRECICE_DEBUG("Synchronize time step size");
-  if (utils::IntraComm::isParallel()) {
-    syncTimestep(computedTimeStepSize);
-  }
-#endif
+  // #ifndef NDEBUG
+  //   PRECICE_DEBUG("Synchronize time step size");
+  //   if (utils::IntraComm::isParallel()) {
+  //     syncTimestep(computedTimeStepSize);
+  //   }
+  // #endif
 
   // Update the coupling scheme time state. Necessary to get correct remainder.
-  const bool isAtWindowEnd   = _couplingScheme->addComputedTime(computedTimeStepSize);
-  bool       performedReinit = false;
-  if (_allowsRemeshing) {
+  const bool isAtWindowEnd          = _couplingScheme->addComputedTime(computedTimeStepSize);
+  bool       requiresSeparateReinit = std::any_of(_accessor->writeDataContexts().begin(), _accessor->writeDataContexts().end(), [&](const auto &v) {
+    return _accessor->isDirectAccessAllowed(v.getMeshName());
+  });
+
+  if (_allowsRemeshing && !requiresSeparateReinit) {
     if (isAtWindowEnd) {
       auto totalMeshChanges = getTotalMeshChanges();
       clearStamplesOfChangedMeshes(totalMeshChanges);
@@ -444,7 +447,6 @@ void ParticipantImpl::advance(
       int sumOfChanges = std::accumulate(totalMeshChanges.begin(), totalMeshChanges.end(), 0);
       if (reinitHandshake(sumOfChanges)) {
         reinitialize();
-        performedReinit = true;
       }
     } else {
       PRECICE_CHECK(_meshLock.checkAll(), "The time window needs to end after remeshing.");
@@ -454,7 +456,7 @@ void ParticipantImpl::advance(
   const double timeSteppedTo = _couplingScheme->getTime();
   const auto   dataToReceive = _couplingScheme->implicitDataToReceive();
 
-  handleDataBeforeAdvance(isAtWindowEnd, timeSteppedTo, performedReinit);
+  handleDataBeforeAdvance(isAtWindowEnd, timeSteppedTo, false);
 
   advanceCouplingScheme();
 
@@ -816,6 +818,41 @@ void ParticipantImpl::resetMeshAccessRegion(std::string_view meshName)
   context.userDefinedAccessRegion.reset();
   context.mesh->resetBoundingBox();
   _meshLock.unlock(meshName);
+}
+
+bool ParticipantImpl::reinitializeAPIAccess()
+{
+  PRECICE_EXPERIMENTAL_API();
+  PRECICE_CHECK(_allowsRemeshing, "Cannot reset access region. This feature needs to be enabled in the precice configuration file using <precice-configuration experimental=\"1\" allow-remeshing=\"1\">.");
+  PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before reinitializeAPIAccess().");
+  PRECICE_CHECK(_couplingScheme->isCouplingOngoing(), "Cannot remesh after the last time window has been completed.");
+  // PRECICE_CHECK(_couplingScheme->isTimeWindowComplete(), "Cannot remesh while subcycling or iterating. Remeshing is only allowed when the time window is completed.");
+
+  auto requiresSeparateReinit = std::any_of(_accessor->writeDataContexts().begin(), _accessor->writeDataContexts().end(), [&](const auto &v) {
+    auto m = v.getMeshName();
+    return _accessor->isMeshReceived(m) && _accessor->isDirectAccessAllowed(m);
+  });
+  PRECICE_CHECK(requiresSeparateReinit, "You tried to use the manual reinitializeAPIAccess, but using reinitializeAPIAccess is only permitted for participants using direct-mesh access or just-in-time mappings in write direction");
+
+  PRECICE_DEBUG("Manually reinitializing via API");
+  // TODO: Maybe we need the dt as an argument
+  const bool isAtWindowEnd             = true; //_couplingScheme->addComputedTime(computedTimeStepSize);
+  bool       performedReinitialization = false;
+  if (_allowsRemeshing) {
+    if (isAtWindowEnd) {
+      auto totalMeshChanges = getTotalMeshChanges();
+      clearStamplesOfChangedMeshes(totalMeshChanges);
+
+      int sumOfChanges = std::accumulate(totalMeshChanges.begin(), totalMeshChanges.end(), 0);
+      if (reinitHandshake(sumOfChanges)) {
+        reinitialize();
+        performedReinitialization = true;
+      }
+    } else {
+      PRECICE_CHECK(_meshLock.checkAll(), "The time window needs to end after remeshing.");
+    }
+  }
+  return performedReinitialization;
 }
 
 VertexID ParticipantImpl::setMeshVertex(

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -146,6 +146,8 @@ public:
   /// @copydoc Participant::resetMeshAccessRegion
   void resetMeshAccessRegion(std::string_view meshName);
 
+  bool reinitializeAPIAccess();
+
   /// @copydoc Participant::requiresMeshConnectivityFor
   bool requiresMeshConnectivityFor(std::string_view meshName) const;
 

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -101,7 +101,7 @@ void WriteDataContext::resizeBufferTo(int nVertices, bool invalidateBufferedData
     _writeDataBuffer.values.tail(change).setZero();
   }
   if (invalidateBufferedData)
-    _writeDataBuffer.values.setConstant(-1);
+    _writeDataBuffer.values.setConstant(0);
 
   PRECICE_DEBUG("Data {} now has {} values", getDataName(), _writeDataBuffer.values.size());
 

--- a/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.cpp
+++ b/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.cpp
@@ -168,15 +168,6 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
         return value * value - value * time;
       });
 
-      if (context.rank == 0) {
-        for (int i = 0; i < expectedMesh.size() / dim; ++i)
-          std::cout << "Writing: Rank 0: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
-      }
-      if (context.rank == 1) {
-        for (int i = 0; i < expectedMesh.size() / dim; ++i)
-          std::cout << "Writing: Rank 1: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
-      }
-
       // write
       interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
       interface.advance(dt);

--- a/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.cpp
+++ b/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.cpp
@@ -63,8 +63,8 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
 
       // There is a duplicate write in the overlap region
       for (std::size_t i = 0; i < meshSize; ++i) {
-        auto start = time > 1 ? 10 : 10;
-        auto end   = time > 1 ? 31 : 31;
+        auto start = time > 1 ? 11 : 10;
+        auto end   = time > 1 ? 32 : 31;
         if (positions[i * dim] > start &&
             positions[i * dim] < end) {
           expectedData[i * dim] *= 2;
@@ -130,23 +130,6 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
       interface.readData(receivedMeshName, readDataName, receiveMeshIDs, dt, readData);
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
 
-      // (artificial) solve: fill writeData
-      std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
-        return value * value - value * time;
-      });
-
-      if (context.rank == 0) {
-        for (int i = 0; i < expectedMesh.size() / dim; ++i)
-          std::cout << "Writing: Rank 0: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
-      }
-      if (context.rank == 1) {
-        for (int i = 0; i < expectedMesh.size() / dim; ++i)
-          std::cout << "Writing: Rank 1: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
-      }
-
-      // write
-      interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
-
       // we can't call this function in the first time step, see #2093
       if (time > 1) {
         interface.resetMeshAccessRegion(receivedMeshName);
@@ -166,19 +149,37 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
 
         interface.setMeshAccessRegion(receivedMeshName, boundingBox);
       }
+
+      if (interface.reinitializeAPIAccess()) {
+        // After advance, we have the new vertices and IDs of the new access region
+        // First, check the sizes
+        receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
+        BOOST_TEST(receivedMeshSize == (expectedMesh.size() / dim));
+
+        // Resize vectors
+        receiveMeshIDs.resize(receivedMeshSize, -1);
+        receivedMesh = writeData = readData = expectedData = std::vector<double>(receivedMeshSize * dim, -1);
+        interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
+
+        BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
+      }
+      // (artificial) solve: fill writeData
+      std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
+        return value * value - value * time;
+      });
+
+      if (context.rank == 0) {
+        for (int i = 0; i < expectedMesh.size() / dim; ++i)
+          std::cout << "Writing: Rank 0: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
+      }
+      if (context.rank == 1) {
+        for (int i = 0; i < expectedMesh.size() / dim; ++i)
+          std::cout << "Writing: Rank 1: " << writeData[dim * i] << "  positions: " << expectedMesh[dim * i] << "  at time: " << time << std::endl;
+      }
+
+      // write
+      interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
       interface.advance(dt);
-
-      // After advance, we have the new vertices and IDs of the new access region
-      // First, check the sizes
-      receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
-      BOOST_TEST(receivedMeshSize == (expectedMesh.size() / dim));
-
-      // Resize vectors
-      receiveMeshIDs.resize(receivedMeshSize, -1);
-      receivedMesh = writeData = readData = expectedData = std::vector<double>(receivedMeshSize * dim, -1);
-      interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
-
-      BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
 
       // the expected data lags one behind, so we generate (the same) reference solution as writeData for SolverOne, one dt later
       std::transform(expectedMesh.begin(), expectedMesh.end(), expectedData.begin(), [&](double value) {

--- a/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.xml
+++ b/tests/parallel/direct-mesh-access/ResetMeshAccessRegion.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:vector name="Velocities" />
+  <data:vector name="Forces" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Velocities" mesh="MeshOne" />
+    <read-data name="Forces" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" api-access="true" />
+    <read-data name="Velocities" mesh="MeshOne" />
+    <write-data name="Forces" mesh="MeshOne" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Forces" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/direct-mesh-access/RemeshReceivedMesh.cpp
+++ b/tests/serial/direct-mesh-access/RemeshReceivedMesh.cpp
@@ -121,29 +121,30 @@ BOOST_AUTO_TEST_CASE(RemeshReceivedMesh)
       interface.readData(receivedMeshName, readDataName, receiveMeshIDs, dt, readData);
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
 
-      // our artificial solve
+      // mesh changes apply
+      if (interface.reinitializeAPIAccess()) {
+        if (time > 1) {
+          expectedMesh.push_back(0.2 + time * 0.1);
+          expectedMesh.push_back(1.25);
+          std::transform(expectedMesh.begin(), expectedMesh.end(), expectedMesh.begin(), [&](double value) {
+            return value + 0.1;
+          });
+        }
+        receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
+        BOOST_TEST(receivedMeshSize == expectedMesh.size() / dim);
+        receiveMeshIDs.resize(receivedMeshSize);
+        writeData = readData = expectedData = receivedMesh = std::vector<double>(receivedMeshSize * dim, -1);
+        interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
+        BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
+      }
+
+      // now we evaluate on the coordinates we received
       std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
         return value * (value + 7.3) - (value + 5) * time;
       });
 
       interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
       interface.advance(dt);
-
-      // mesh changes apply
-      if (time > 1) {
-        expectedMesh.push_back(0.2 + time * 0.1);
-        expectedMesh.push_back(1.25);
-        std::transform(expectedMesh.begin(), expectedMesh.end(), expectedMesh.begin(), [&](double value) {
-          return value + 0.1;
-        });
-      }
-
-      receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
-      BOOST_TEST(receivedMeshSize == expectedMesh.size() / dim);
-      receiveMeshIDs.resize(receivedMeshSize);
-      writeData = readData = expectedData = receivedMesh = std::vector<double>(receivedMeshSize * dim, -1);
-      interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
-      BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
 
       // and the new reference data, according to the 'write' formula on the other participant (before we increment the time)
       std::transform(expectedMesh.begin(), expectedMesh.end(), expectedData.begin(), [&](double value) {

--- a/tests/serial/direct-mesh-access/ResetMeshAccessRegion.cpp
+++ b/tests/serial/direct-mesh-access/ResetMeshAccessRegion.cpp
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
 
       // read
       interface.readData(providedMeshName, readDataName, ids, dt, readData);
+
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
 
       // expected Data (lags one dt behind due to coupling scheme)
@@ -57,11 +58,13 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
       });
 
       // We manually account for values excluded due to the access region
-      if (time < 3) {
+      if (time == 1 /* || time == 2*/) {
         expectedData[2 * dim] = expectedData[2 * dim + 1] = 0;
-      } else if (time < 4) {
+      }
+      if (time == 2) {
         expectedData[0 * dim] = expectedData[0 * dim + 1] = 0;
-      } else {
+      }
+      if (time == 3) {
         expectedData[0 * dim] = expectedData[0 * dim + 1] = 0;
         expectedData[1 * dim] = expectedData[1 * dim + 1] = 0;
       }
@@ -125,14 +128,6 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
       interface.readData(receivedMeshName, readDataName, receiveMeshIDs, dt, readData);
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
 
-      // (artificial) solve: fill writeData
-      std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
-        return value * value - value * time;
-      });
-
-      // write
-      interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
-
       // we can't call this function in the first time step, see #2093
       if (time > 1 && time < 4) {
         interface.resetMeshAccessRegion(receivedMeshName);
@@ -145,19 +140,25 @@ BOOST_AUTO_TEST_CASE(ResetMeshAccessRegion)
         expectedMesh = std::vector<double>(startIter, endIter);
         interface.setMeshAccessRegion(receivedMeshName, boundingBox);
       }
+
+      if (interface.reinitializeAPIAccess()) {
+        // First, check the sizes
+        receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
+        BOOST_TEST(receivedMeshSize == (expectedMesh.size() / dim));
+
+        // Resize vectors
+        receiveMeshIDs.resize(receivedMeshSize, -1);
+        receivedMesh = writeData = readData = expectedData = std::vector<double>(receivedMeshSize * dim, -1);
+        interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
+        BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
+      }
+      // (artificial) solve: fill writeData  and write
+      std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
+        return value * value - value * time;
+      });
+
+      interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
       interface.advance(dt);
-
-      // After advance, we have the new vertices and IDs of the new access region
-      // First, check the sizes
-      receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
-      BOOST_TEST(receivedMeshSize == (expectedMesh.size() / dim));
-
-      // Resize vectors
-      receiveMeshIDs.resize(receivedMeshSize, -1);
-      receivedMesh = writeData = readData = expectedData = std::vector<double>(receivedMeshSize * dim, -1);
-      interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
-
-      BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
 
       // the expected data lags one behind, so we generate (the same) reference solution as writeData for SolverOne, one dt later
       std::transform(expectedMesh.begin(), expectedMesh.end(), expectedData.begin(), [&](double value) {


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
